### PR TITLE
[Feat] 동적 Resolver 등록 기능

### DIFF
--- a/backend/src/decorator/mutation.decorator.ts
+++ b/backend/src/decorator/mutation.decorator.ts
@@ -1,0 +1,12 @@
+export default function Mutation() {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    if (!target.constructor.mutations) {
+      target.constructor.mutations = [];
+    }
+    target.constructor.mutations.push(propertyKey);
+  };
+}

--- a/backend/src/decorator/query.decorator.ts
+++ b/backend/src/decorator/query.decorator.ts
@@ -1,0 +1,12 @@
+export default function Query() {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    if (!target.constructor.queries) {
+      target.constructor.queries = [];
+    }
+    target.constructor.queries.push(propertyKey);
+  };
+}

--- a/backend/src/expense/resolver/expense.resolver.ts
+++ b/backend/src/expense/resolver/expense.resolver.ts
@@ -1,79 +1,37 @@
-import { Expense } from "../model/Expense";
+import Mutation from "../../decorator/mutation.decorator";
+import Query from "../../decorator/query.decorator";
+import { ExpenseInput, ExpenseUpdate } from "../../type/expense.type";
+import { ExpenseService } from "../service/expense.service";
 
-export const expenseResolvers = {
-  Query: {
-    getExpenses: async () => {
-      return await Expense.find();
-    },
+export class ExpenseResolver {
+  private expenseService: ExpenseService;
 
-    getExpense: async (_: any, { id }: { id: string }) => {
-      return await Expense.findById(id);
-    },
-  },
+  constructor() {
+    this.expenseService = new ExpenseService();
+  }
 
-  Mutation: {
-    addExpense: async (
-      _: any,
-      {
-        title,
-        amount,
-        category,
-        date,
-        description,
-      }: {
-        title: string;
-        amount: number;
-        category: string;
-        date: string;
-        description: string | null;
-      }
-    ) => {
-      const newExpense = new Expense({
-        title,
-        amount,
-        category,
-        date,
-        description,
-      });
-      await newExpense.save();
-      return newExpense;
-    },
+  @Query()
+  public async getExpenses() {
+    return await this.expenseService.getExpenses();
+  }
 
-    updateExpense: async (
-      _: any,
-      {
-        id,
-        title,
-        amount,
-        category,
-        date,
-        description,
-      }: {
-        id: string;
-        title?: string;
-        amount?: number;
-        category?: string;
-        date?: string;
-        description?: string | null;
-      }
-    ) => {
-      const updatedExpense = await Expense.findByIdAndUpdate(
-        id,
-        { title, amount, category, date, description },
-        { new: true }
-      );
-      if (!updatedExpense) {
-        throw new Error("Expense not found");
-      }
-      return updatedExpense;
-    },
+  @Query()
+  public async getExpense(_: any, { id }: { id: string }) {
+    return await this.expenseService.getExpense(id);
+  }
 
-    deleteExpense: async (_: any, { id }: { id: string }) => {
-      const deletedExpense = await Expense.findByIdAndDelete(id);
-      if (!deletedExpense) {
-        throw new Error("Expense not found");
-      }
-      return true;
-    },
-  },
-};
+  @Mutation()
+  public async addExpense(_: any, expenseInput: ExpenseInput) {
+    return await this.expenseService.addExpense(expenseInput);
+  }
+
+  @Mutation()
+  public async updateExpense(_: any, expenseUpdate: ExpenseUpdate) {
+    return await this.expenseService.updateExpense(expenseUpdate);
+  }
+
+  @Mutation()
+  public async deleteExpense(_: any, { id }: { id: string }) {
+    return await this.expenseService.deleteExpense(id);
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,19 +1,18 @@
 import { ApolloServer } from "apollo-server";
 import { connectDB } from "./db/db.config";
 import { loadFiles } from "@graphql-tools/load-files";
-import { expenseResolvers } from "./expense/resolver/expense.resolver";
+import { ExpenseResolver } from "./expense/resolver/expense.resolver";
+import { registResolvers } from "./util/registResolvers";
 
 async function startServer() {
   connectDB();
 
   const typeDefs = await loadFiles("./src/**/schema/*.graphql");
+  const resolvers = registResolvers([ExpenseResolver]);
 
   const server = new ApolloServer({
     typeDefs,
-    resolvers: {
-      Query: expenseResolvers.Query,
-      Mutation: expenseResolvers.Mutation,
-    },
+    resolvers,
   });
 
   server.listen(4000).then(({ url }) => {

--- a/backend/src/type/expense.type.ts
+++ b/backend/src/type/expense.type.ts
@@ -1,0 +1,13 @@
+export interface ExpenseBase {
+  title: string;
+  amount: number;
+  category: string;
+  date: string;
+  description: string | null;
+}
+
+export type ExpenseInput = ExpenseBase;
+
+export interface ExpenseUpdate extends Partial<ExpenseBase> {
+  id: string;
+}

--- a/backend/src/util/registResolvers.ts
+++ b/backend/src/util/registResolvers.ts
@@ -1,0 +1,22 @@
+export function registResolvers(resolverClasses: any[]) {
+  const resolvers: any = {
+    Query: {},
+    Mutation: {},
+  };
+
+  try {
+    resolverClasses.forEach((resolver) => {
+      resolver.queries.forEach((methodName: any) => {
+        resolvers.Query[methodName] = new resolver()[methodName];
+      });
+
+      resolver.mutations.forEach((methodName: any) => {
+        resolvers.Mutation[methodName] = new resolver()[methodName];
+      });
+    });
+  } catch (error) {
+    throw new Error("Error in registResolvers: " + error);
+  }
+
+  return resolvers;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -11,10 +11,10 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    "experimentalDecorators": true /* Enable experimental support for legacy experimental decorators. */,
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
     // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
@@ -25,7 +25,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -76,12 +76,12 @@
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -103,6 +103,6 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
## 🔥 관련 이슈 번호
close #9 

## 🚀 작업 내용

- [x] `@Query`, `@Mutation` 작성
- [x] Resolver 클래스에 데코레이터 적용
- [x] Resolver 동적 등록 로직 구현

## 설명

### `@Query`, `@Mutation` 작성
ApolloServer는 Resolver를 등록할 때, Query와 Mutation을 구분하여 전달해줘야 함.
따라서, Resolver 클래스에서 메서드들을 분류할 필요가 있었음.
가독성, 확장성, 구현 용이성 등을 고려하여, 데코레이터를 활용하기로 결정.

### Resolver 동적 등록 로직 구현
클래스만 배열에 추가해주면, 나머지는 자동으로 등록되도록 구현하고 싶었음.
그래서, registResolver라는 util 함수를 만들어 전달 받은 클래스 배열을 Resovler 등록 형식에 맞는 Object형태로 가공하도록 함. 